### PR TITLE
Add latest samsung internet android releases

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -285,9 +285,20 @@
         },
         "25.0": {
           "release_date": "2024-04-24",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "121"
+        },
+        "26.0": {
+          "release_date": "2024-06-07",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "122"
+        },
+        "27.0": {
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "125"
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

it's really hard to find information on Samsung Internet, but version 26 is the current version according to http://www.samsungapps.com/appquery/appDetail.as?appId=com.sec.android.app.sbrowser

- Samsung Internet 26: taken the earliest apk version date from https://www.apkmirror.com/uploads/?appcategory=samsung-internet-for-android
- Samsung Internet 27: https://github.com/zloirock/core-js/commit/3dec7ddeb0187a6dd4aeb318628c4558a9828c64

#### Test results and supporting details

no available release notes that I could find.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
